### PR TITLE
Add gcc-11 build and use Ninja.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,33 +20,45 @@ jobs:
 
           # Linux builds
           # ~~~~~~~~~~~~
+          - name: Ubuntu-22.04/gcc-11/Debug
+            apt_install: ninja-build
+            build_type: Debug
+            generator: Ninja
+            os: ubuntu-22.04
+
+          - name: Ubuntu-22.04/gcc-11/Release
+            apt_install: ninja-build
+            build_type: Release
+            generator: Ninja
+            os: ubuntu-22.04
+
           - name: Ubuntu-22.04/gcc-12/Debug
-            apt_install: g++-12 libstdc++-12-dev
+            apt_install: g++-12 libstdc++-12-dev ninja-build
             build_type: Debug
             cxx_compiler: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
-            generator: Unix Makefiles
+            generator: Ninja
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/gcc-12/Release
-            apt_install: g++-12 libstdc++-12-dev
+            apt_install: g++-12 libstdc++-12-dev ninja-build
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
-            generator: Unix Makefiles
+            generator: Ninja
             os: ubuntu-22.04
 
+          # It's current necesssary to use libc++ because builds witb libstdc++ fail
+          # They fail due to this bug:
+          # https://github.com/llvm/llvm-project/issues/55560
+
           - name: Ubuntu-22.04/clang-14/Debug
+            apt_install: libc++-dev libc++abi-dev ninja-build
             build_type: Debug
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
-            generator: Unix Makefiles
+            generator: Ninja
+            options: -DLIBCXX=Yes '-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold'
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-14/Release
-            build_type: Release
-            cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
-            generator: Unix Makefiles
-            os: ubuntu-22.04
-
-          - name: Ubuntu-22.04/clang-14/libc++/Release
             apt_install: libc++-dev libc++abi-dev ninja-build
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
@@ -55,9 +67,10 @@ jobs:
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-14/Release/C++17
+            apt_install: ninja-build
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
-            generator: Unix Makefiles
+            generator: Ninja
             options: -DCXX17=Yes -DLIBCXX=Yes -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
             os: ubuntu-22.04
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ jobs:
             generator: Xcode
             os: macos-12
 
-          # Ubuntu builds
-          # ~~~~~~~~~~~~~
+          # Linux builds
+          # ~~~~~~~~~~~~
           - name: Ubuntu-22.04/gcc-12/Debug
             apt_install: g++-12 libstdc++-12-dev
             build_type: Debug
@@ -34,28 +34,27 @@ jobs:
             generator: Unix Makefiles
             os: ubuntu-22.04
 
-          # It's current necesssary to use libc++ because builds witb libstdc++ fail
-          # They fail due to this bug:
-          # https://github.com/llvm/llvm-project/issues/55560
-
           - name: Ubuntu-22.04/clang-14/Debug
-            apt_install: libc++-dev libc++abi-dev
             build_type: Debug
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
             generator: Unix Makefiles
-            options: -DLIBCXX=Yes '-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold'
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-14/Release
-            apt_install: libc++-dev libc++abi-dev
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
             generator: Unix Makefiles
+            os: ubuntu-22.04
+
+          - name: Ubuntu-22.04/clang-14/libc++/Release
+            apt_install: libc++-dev libc++abi-dev ninja-build
+            build_type: Release
+            cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
+            generator: Ninja
             options: -DLIBCXX=Yes '-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold'
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-14/Release/C++17
-            apt_install: libc++-dev libc++abi-dev
             build_type: Release
             cxx_compiler: -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_COMPILER=clang-14
             generator: Unix Makefiles


### PR DESCRIPTION
Commit aa518e9bc2189e64da3a3cc52e1d2a308f35f0cd means that we're now able to restore the gcc-11 builds. That's significant because it's the default compiler on Ubuntu 22.

Use ninja rather than make: might see improved build times.