### PR TITLE
Improve cmake messages for KLEE targets. Break CI in two.

### DIFF
--- a/.github/workflows/klee.yaml
+++ b/.github/workflows/klee.yaml
@@ -13,6 +13,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
   workflow_dispatch:
+
 permissions:
   contents: read
 
@@ -89,9 +90,11 @@ jobs:
                 -D LIBCXX=Yes                      \
                 -D WERROR=Yes
 
-      - name: Build and Test
-        run: |
-          cmake --build "${{ github.workspace }}/build" --target klee-all
+      - name: KLEE Build
+        run: cmake --build "${{ github.workspace }}/build" --target klee-build-all
+
+      - name: KLEE Test
+        run: cmake --build "${{ github.workspace }}/build" --target klee-all
 
       - name: Compress Test Outputs
         run: |

--- a/klee/CMakeLists.txt
+++ b/klee/CMakeLists.txt
@@ -73,6 +73,8 @@ function (add_klee_target)
   set (exe_target "${target_base}-exe")
   set (run_target "${target_base}-run")
 
+  message (STATUS "Adding KLEE targets klee-${target_base}-bc/exe/run")
+
   # Bitcode Target
 
   add_library (${bitcode_target} OBJECT ${sources})
@@ -126,12 +128,14 @@ function (add_klee_target)
   )
 
   add_dependencies (klee-all ${run_target})
+  add_dependencies (klee-build-all ${bitcode_target} ${exe_target})
 endfunction (add_klee_target)
 
 klee_is_available (klee_available)
 message (STATUS "KLEE available? ${klee_available}")
 if (klee_available)
   add_custom_target (klee-all)
+  add_custom_target (klee-build-all)
 
   # Calls to add_klee_target of the form:
   set (
@@ -164,7 +168,6 @@ if (klee_available)
     quote
   )
   foreach (T ${TESTS})
-    message (STATUS "Adding KLEE test ${T}")
     add_klee_target (TARGET klee-${T} SOURCES ${T}.cpp)
   endforeach ()
 


### PR DESCRIPTION
The KLEE CI workflow is broken into the "build" and "test" steps.