### PR TITLE
Don't link gtest to avoid macOS ld warning.

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable (
   test_whitespace.cpp
 )
 setup_target (pj-unittests)
-target_link_libraries (pj-unittests PRIVATE peejay gtest gmock)
+target_link_libraries (pj-unittests PRIVATE peejay gmock)
 
 set (clang_options -Wno-global-constructors -Wno-used-but-marked-unused)
 set (gcc_options)


### PR DESCRIPTION
When linking pj-unittests, the macOS linker was issuing a warning `ld: warning: ignoring duplicate libraries: '.../peejay/build_mac/lib/Debug/libgtest.a'`

This happened because gmock adds the gtest target already (see ./googletest/googlemock/CMakeLists.txt). Including it again in our CMakeLists file is unnecessary.