### PR TITLE
Workaround for Coverity CID1571023.

### DIFF
--- a/unittests/test_dom.cpp
+++ b/unittests/test_dom.cpp
@@ -196,7 +196,9 @@ TEST_F (Dom, ArrayInsideObject) {
   ASSERT_THAT (
       obj, UnorderedElementsAre (Pair (u8"a"s, VariantWith<array> (_)),
                                  Pair (u8"b"s, VariantWith<std::int64_t> (3))));
-  auto const &arr = *std::get<array> (obj.find (u8"a")->second);
+  auto const pos = obj.find (u8"a");
+  ASSERT_NE (pos, obj.end ());
+  auto const &arr = *std::get<array> (pos->second);
   ASSERT_THAT (arr, ElementsAre (VariantWith<std::int64_t> (1),
                                  VariantWith<std::int64_t> (2)));
 }


### PR DESCRIPTION
Coverity thinks that there is a path which does not check that the call to find() will not return end(). In fact, the previous ASSERT should already have checked this, but however... This adds an additional use of ASSERT_NE to guarantee the validity of the iterator returned by find().