### PR TITLE
small_vector CTAD / eliminate transfer_from_same()

### DIFF
--- a/include/peejay/small_vector.hpp
+++ b/include/peejay/small_vector.hpp
@@ -448,6 +448,9 @@ private:
   large_type &to_large ();
 };
 
+template <typename ElementType>
+small_vector (ElementType) -> small_vector<ElementType>;
+
 // (ctor)
 // ~~~~~~
 template <typename ElementType, std::size_t BodyElements, typename Allocator>


### PR DESCRIPTION
- Add a simple CTAD guide to `small_vector<>`.
- Eliminate the `transfer_from_same()` members.

  Coverity CID1569248 is under the impression that the `transfer_from_same()` function could throw if the variant was storing a ype with index other than the function's Index template argument. The two being the same was, however, a precondition of calling the function.

  Since the two versions of `transfer_from_same()` was called only once each, I think that inlining them in the location that the precondition is established makes more sense than having them as separate functions.
